### PR TITLE
FIX: Make getPopUp() return type nullable to handle empty results

### DIFF
--- a/src/Extension/PageControllerExtension.php
+++ b/src/Extension/PageControllerExtension.php
@@ -24,9 +24,9 @@ class PageControllerExtension extends Extension
     }
 
     /**
-     * @return PopUp
+     * @return PopUp|null
      */
-    public function getPopUp(): PopUp
+    public function getPopUp(): ?PopUp
     {
         $list = PopUp::get()->filter([
             'StartTime:LessThanOrEqual' => date("Y-m-d H:i:s", strtotime('now')),


### PR DESCRIPTION
## Summary
Fixes a TypeError that occurs when `getPopUp()` returns `null` but the return type is declared as non-nullable `PopUp`.

## Problem
When no popups match the time-based filters or cookie filters, the method returns `null` (from `first()` on an empty list), but the return type declaration requires a `PopUp` object, causing:
```
TypeError: Dynamic\Notifications\Extension\PageControllerExtension::getPopUp(): Return value must be of type Dynamic\Notifications\Model\PopUp, null returned
```

## Solution
- Changed return type from `PopUp` to `?PopUp` (nullable)
- Updated PHPDoc to reflect nullable return: `@return PopUp|null`
- Template already handles null check properly with `<% if $PopUp %>`

## Testing
Tested scenarios where no popups are returned:
- Popups with future StartTime (not yet active)
- Popups with past EndTime (expired)
- Popups filtered out by ShowOnce cookie
- All scenarios now work without TypeError

## Impact
- Fixes bug without breaking changes
- Templates already check for null values
- No migration needed