### PR TITLE
ENHANCEMENT: Add template rendering with AJAX deprecation

### DIFF
--- a/client/js/notifications.js
+++ b/client/js/notifications.js
@@ -1,4 +1,14 @@
+/**
+ * @deprecated 3.0.0 AJAX violator loading is deprecated. Use template rendering instead.
+ * This file will be removed in version 3.0.0.
+ * To disable this warning, set PageController.use_ajax_violators to false in your config.
+ */
 window.addEventListener('load', function() {
+  console.warn(
+    'AJAX violator loading is deprecated and will be removed in version 3.0.0. ' +
+    'Please use template rendering instead by setting PageController.use_ajax_violators to false.'
+  );
+  
   var xhr = new XMLHttpRequest();
   var url = '/violatordata?isAjax=1';
 

--- a/client/js/violator.js
+++ b/client/js/violator.js
@@ -45,8 +45,8 @@
     var ca = document.cookie.split(';');
     for (var i = 0; i < ca.length; i++) {
       var c = ca[i];
-      while (c.charAt(0) == ' ') c = c.substring(1, c.length);
-      if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+      while (c.charAt(0) === ' ') c = c.substring(1, c.length);
+      if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
     }
     return null;
   }

--- a/client/js/violator.js
+++ b/client/js/violator.js
@@ -1,0 +1,53 @@
+/**
+ * Violator cookie handling for template-rendered violators
+ * Handles "show once" functionality using cookies
+ */
+(function() {
+  'use strict';
+
+  // Wait for DOM to be ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initViolators);
+  } else {
+    initViolators();
+  }
+
+  function initViolators() {
+    var violators = document.querySelectorAll('.violators__violator[data-cookiename]');
+    
+    violators.forEach(function(violator) {
+      var cookieName = violator.getAttribute('data-cookiename');
+      
+      // Hide if cookie exists
+      if (getCookie(cookieName)) {
+        violator.style.display = 'none';
+      } else {
+        // Add event listener to close button
+        var closeButton = violator.querySelector('.btn-close');
+        if (closeButton) {
+          closeButton.addEventListener('click', function() {
+            setCookie(cookieName, 'true', 365);
+          });
+        }
+      }
+    });
+  }
+
+  function setCookie(name, value, days) {
+    var date = new Date();
+    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+    var expires = "expires=" + date.toUTCString();
+    document.cookie = name + "=" + value + ";" + expires + ";path=/";
+  }
+
+  function getCookie(name) {
+    var nameEQ = name + "=";
+    var ca = document.cookie.split(';');
+    for (var i = 0; i < ca.length; i++) {
+      var c = ca[i];
+      while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+      if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+    }
+    return null;
+  }
+})();

--- a/src/Controller/ViolatorController.php
+++ b/src/Controller/ViolatorController.php
@@ -9,7 +9,7 @@ use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Versioned\Versioned;
 
 /**
- *
+ * @deprecated 3.0.0 Use template rendering via PageControllerExtension::getViolators() instead of AJAX loading
  */
 class ViolatorController extends Controller
 {
@@ -31,6 +31,7 @@ class ViolatorController extends Controller
     }
 
     /**
+     * @deprecated 3.0.0 Use template rendering instead of AJAX loading
      * @return DBHTMLText|null
      */
     public function index(): ?DBHTMLText

--- a/src/Extension/PageControllerExtension.php
+++ b/src/Extension/PageControllerExtension.php
@@ -39,7 +39,7 @@ class PageControllerExtension extends Extension
             // Use template rendering with cookie handling
             Requirements::javascript('dynamic/silverstripe-site-notifications: client/js/violator.js');
         }
-        
+
         Requirements::javascript('dynamic/silverstripe-site-notifications: client/js/popup.js');
     }
 
@@ -73,15 +73,15 @@ class PageControllerExtension extends Extension
      */
     public function getViolators(): ArrayList
     {
-        $now = date("Y-m-d H:i:s", strtotime('now'));
+        $now = date("Y-m-d H:i:s");
         $list = Violator::get();
 
         $list = $list->filterByCallback(function ($item) use ($now) {
             // Check date range - if dates are set, violator must be within range
-            if ($item->StartTime && $item->StartTime > $now) {
+            if ($item->StartTime && $item->StartTime >= $now) {
                 return false;
             }
-            if ($item->EndTime && $item->EndTime < $now) {
+            if ($item->EndTime && $item->EndTime <= $now) {
                 return false;
             }
 

--- a/src/Extension/PageControllerExtension.php
+++ b/src/Extension/PageControllerExtension.php
@@ -3,6 +3,7 @@
 namespace Dynamic\Notifications\Extension;
 
 use Dynamic\Notifications\Model\PopUp;
+use Dynamic\Notifications\Model\Violator;
 use SilverStripe\Control\Cookie;
 use SilverStripe\Core\Extension;
 use SilverStripe\ORM\ArrayList;
@@ -15,11 +16,30 @@ use SilverStripe\View\Requirements;
 class PageControllerExtension extends Extension
 {
     /**
+     * @var bool
+     * @config
+     * @deprecated 3.0.0 Use template rendering instead of AJAX loading
+     */
+    private static $use_ajax_violators = false;
+
+    /**
      * @return void
      */
     public function onAfterInit(): void
     {
-        Requirements::javascript('dynamic/silverstripe-site-notifications: client/js/notifications.js');
+        // AJAX loading is deprecated but still supported for backwards compatibility
+        if ($this->owner->config()->get('use_ajax_violators')) {
+            user_error(
+                'AJAX violator loading is deprecated and will be removed in version 3.0.0. ' .
+                'Set PageController.use_ajax_violators to false and use template rendering instead.',
+                E_USER_DEPRECATED
+            );
+            Requirements::javascript('dynamic/silverstripe-site-notifications: client/js/notifications.js');
+        } else {
+            // Use template rendering with cookie handling
+            Requirements::javascript('dynamic/silverstripe-site-notifications: client/js/violator.js');
+        }
+        
         Requirements::javascript('dynamic/silverstripe-site-notifications: client/js/popup.js');
     }
 
@@ -44,5 +64,35 @@ class PageControllerExtension extends Extension
         });
 
         return $list->shuffle()->first();
+    }
+
+    /**
+     * Get active violators for template rendering
+     * 
+     * @return ArrayList<Violator>
+     */
+    public function getViolators(): ArrayList
+    {
+        $now = date("Y-m-d H:i:s", strtotime('now'));
+        $list = Violator::get();
+
+        $list = $list->filterByCallback(function ($item) use ($now) {
+            // Check date range - if dates are set, violator must be within range
+            if ($item->StartTime && $item->StartTime > $now) {
+                return false;
+            }
+            if ($item->EndTime && $item->EndTime < $now) {
+                return false;
+            }
+
+            // Check ShowOnce cookie
+            if ($item->ShowOnce && Cookie::get($item->CookieName)) {
+                return false;
+            }
+
+            return true;
+        });
+
+        return $list->sort('Sort');
     }
 }

--- a/templates/Includes/Violator.ss
+++ b/templates/Includes/Violator.ss
@@ -1,6 +1,10 @@
 <% if $Violators %>
     <% loop $Violators %>
-        <div id="violator-{$ID}" class="violators__violator container-fluid text-center alert alert-warning alert-dismissible mb-0 border-top-0 border-end-0 border-start-0 rounded-0<% if $Last %> border-bottom-0<% end_if %>" role="alert"<% if $ShowOnce %> data-cookiename="$CookieName"<% end_if %>>
+        <% set $violatorClass = "violators__violator container-fluid text-center alert alert-warning alert-dismissible mb-0 border-top-0 border-end-0 border-start-0 rounded-0" %>
+        <% if $Last %>
+            <% set $violatorClass = "$violatorClass border-bottom-0" %>
+        <% end_if %>
+        <div id="violator-{$ID}" class="$violatorClass" role="alert"<% if $ShowOnce %> data-cookiename="$CookieName"<% end_if %>>
             <strong>$Title</strong>
             <div class="violator-text">
                 $Content

--- a/templates/Includes/Violator.ss
+++ b/templates/Includes/Violator.ss
@@ -1,2 +1,11 @@
-<div class="violators" role="alert">
-</div>
+<% if $Violators %>
+    <% loop $Violators %>
+        <div id="violator-{$ID}" class="violators__violator container-fluid text-center alert alert-warning alert-dismissible mb-0 border-top-0 border-end-0 border-start-0 rounded-0<% if $Last %> border-bottom-0<% end_if %>" role="alert"<% if $ShowOnce %> data-cookiename="$CookieName"<% end_if %>>
+            <strong>$Title</strong>
+            <div class="violator-text">
+                $Content
+            </div>
+            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    <% end_loop %>
+<% end_if %>


### PR DESCRIPTION
## Overview
This PR transitions violator rendering from AJAX-only to template rendering as the default approach, while maintaining backwards compatibility with the deprecated AJAX method.

## Changes

### New Functionality
- **Template Rendering**: Added `PageControllerExtension::getViolators()` method to retrieve violators for template rendering
- **Cookie Handling**: Created `violator.js` to handle "Show Once" cookies for template-rendered violators
- **Nullable Date Support**: Fixed date filtering to properly handle violators with NULL `StartTime`/`EndTime` (always active)
- **Bootstrap 5 Integration**: Updated `Violator.ss` template with proper Bootstrap 5 alert markup

### Deprecation Strategy (Target: 3.0.0)
- **Config Flag**: Added `PageController.use_ajax_violators` (default: `false`)
- **Runtime Warning**: Added `E_USER_DEPRECATED` when AJAX mode is enabled
- **Code Annotations**: Added `@deprecated 3.0.0` to:
  - `ViolatorController` class and methods
  - `notifications.js` (JSDoc + console warning)
- **Backwards Compatibility**: AJAX approach still functional when explicitly enabled

### Bug Fixes
- **Date Filtering**: Violators without date constraints (`NULL` values) now display correctly as "always active"
- **Cookie Filtering**: Server-side cookie checking prevents violators from rendering when "Show Once" cookie exists

## Testing Completed
- ✅ Multiple violators display correctly
- ✅ "Show Once" cookie functionality works
- ✅ Nullable dates handled properly
- ✅ Bootstrap dismissible alerts function correctly
- ✅ Independent dismissal of multiple violators
- ✅ Cookie persistence across page loads

## Migration Path
Existing implementations using AJAX will see a deprecation warning but continue to work. To migrate:
1. Remove `PageController.use_ajax_violators: true` from config (if set)
2. Ensure templates include `<% include Violator %>`
3. Test "Show Once" functionality

## Related Issues
- Closes #17 (if applicable - PHPCS linting tracked separately)