### PR TITLE
feat: Silverstripe 6 compatibility (3.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+vendor/
+composer.lock

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Display site notifications like violators and pop ups
 
 ## Requirements
 
-* SilverStripe ^4.0
-* dynamic/silverstripe-linkable ^1.0
+* Silverstripe ^6
+* silverstripe/linkfield ^5
 
 ## Installation
 

--- a/client/js/notifications.js
+++ b/client/js/notifications.js
@@ -1,4 +1,14 @@
+/**
+ * @deprecated 3.0.0 AJAX violator loading is deprecated. Use template rendering instead.
+ * This file will be removed in version 3.0.0.
+ * To disable this warning, set PageController.use_ajax_violators to false in your config.
+ */
 window.addEventListener('load', function() {
+  console.warn(
+    'AJAX violator loading is deprecated and will be removed in version 3.0.0. ' +
+    'Please use template rendering instead by setting PageController.use_ajax_violators to false.'
+  );
+  
   var xhr = new XMLHttpRequest();
   var url = '/violatordata?isAjax=1';
 

--- a/client/js/notifications.js
+++ b/client/js/notifications.js
@@ -1,6 +1,16 @@
 window.addEventListener('load', function() {
   var xhr = new XMLHttpRequest();
-  xhr.open('GET', '/violatordata?isAjax=1', true);
+  var url = '/violatordata?isAjax=1';
+
+  // Append stage=Stage to the URL if not already present
+  var currentUrl = new URL(window.location.href);
+  var params = currentUrl.searchParams;
+
+  if (params.has('stage') && params.get('stage') === 'Stage') {
+    url = url + '&stage=Stage';
+  }
+
+  xhr.open('GET', url, true);
 
   xhr.onload = function() {
     if (xhr.status >= 200 && xhr.status < 400) {

--- a/client/js/violator.js
+++ b/client/js/violator.js
@@ -1,0 +1,53 @@
+/**
+ * Violator cookie handling for template-rendered violators
+ * Handles "show once" functionality using cookies
+ */
+(function() {
+  'use strict';
+
+  // Wait for DOM to be ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initViolators);
+  } else {
+    initViolators();
+  }
+
+  function initViolators() {
+    var violators = document.querySelectorAll('.violators__violator[data-cookiename]');
+    
+    violators.forEach(function(violator) {
+      var cookieName = violator.getAttribute('data-cookiename');
+      
+      // Hide if cookie exists
+      if (getCookie(cookieName)) {
+        violator.style.display = 'none';
+      } else {
+        // Add event listener to close button
+        var closeButton = violator.querySelector('.btn-close');
+        if (closeButton) {
+          closeButton.addEventListener('click', function() {
+            setCookie(cookieName, 'true', 365);
+          });
+        }
+      }
+    });
+  }
+
+  function setCookie(name, value, days) {
+    var date = new Date();
+    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+    var expires = "expires=" + date.toUTCString();
+    document.cookie = name + "=" + value + ";" + expires + ";path=/";
+  }
+
+  function getCookie(name) {
+    var nameEQ = name + "=";
+    var ca = document.cookie.split(';');
+    for (var i = 0; i < ca.length; i++) {
+      var c = ca[i];
+      while (c.charAt(0) === ' ') c = c.substring(1, c.length);
+      if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
+    }
+    return null;
+  }
+})();

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
             "client/js"
         ],
         "branch-alias": {
-            "dev-3": "3.x-dev"
+            "dev-master": "3.x-dev"
         }
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "silverstripe/linkfield":"^4.0",
-        "silverstripe/recipe-cms": "^5.0"
+        "silverstripe/recipe-cms": "^5.0 || ^6.0"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3",
+        "silverstripe/recipe-testing": "^3 || ^4",
         "dnadesign/silverstripe-elemental": "^5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/linkfield":"^4.0",
+        "silverstripe/linkfield": "^4.0 || ^5.0",
         "silverstripe/recipe-cms": "^5.0 || ^6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "authors": [
         {
             "name": "Dynamic",
-            "email": "dev@dyamicagency.com",
+            "email": "dev@dynamicagency.com",
             "homepage": "https://www.dynamicagency.com"
         }
     ],
@@ -15,12 +15,13 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/linkfield": "^4.0 || ^5.0",
-        "silverstripe/recipe-cms": "^5.0 || ^6.0"
+        "silverstripe/linkfield": "^5",
+        "silverstripe/recipe-cms": "^6",
+        "silverstripe/vendor-plugin": "^3"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3 || ^4",
-        "dnadesign/silverstripe-elemental": "^5"
+        "silverstripe/recipe-testing": "^4",
+        "dnadesign/silverstripe-elemental": "^6"
     },
     "autoload": {
         "psr-4": {
@@ -31,7 +32,10 @@
     "extra": {
         "expose": [
             "client/js"
-        ]
+        ],
+        "branch-alias": {
+            "dev-3": "3.x-dev"
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,16 @@
-<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/silverstripe/cms/tests/bootstrap.php"
+         colors="true">
     <testsuites>
         <testsuite name="silverstripe-site-notifications">
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>

--- a/src/Controller/ViolatorController.php
+++ b/src/Controller/ViolatorController.php
@@ -6,6 +6,7 @@ use Dynamic\Notifications\Model\Violator;
 use SilverStripe\Control\Controller;
 use SilverStripe\Dev\Debug;
 use SilverStripe\ORM\FieldType\DBHTMLText;
+use SilverStripe\Versioned\Versioned;
 
 /**
  *
@@ -34,7 +35,15 @@ class ViolatorController extends Controller
      */
     public function index(): ?DBHTMLText
     {
-        $list = Violator::get()->filter([
+        $stage = $this->getRequest()->getVar('stage');
+
+        if ($stage === 'Stage') {
+            $list = Versioned::get_by_stage(Violator::class, Versioned::DRAFT);
+        } else {
+            $list = Versioned::get_by_stage(Violator::class, Versioned::LIVE);
+        }
+
+        $list = $list->filter([
             'StartTime:LessThanOrEqual' => date("Y-m-d H:i:s", strtotime('now')),
             'EndTime:GreaterThanOrEqual' => date("Y-m-d H:i:s", strtotime('now')),
         ]);

--- a/src/Controller/ViolatorController.php
+++ b/src/Controller/ViolatorController.php
@@ -9,7 +9,7 @@ use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Versioned\Versioned;
 
 /**
- *
+ * @deprecated 3.0.0 Use template rendering via PageControllerExtension::getViolators() instead of AJAX loading
  */
 class ViolatorController extends Controller
 {
@@ -31,6 +31,7 @@ class ViolatorController extends Controller
     }
 
     /**
+     * @deprecated 3.0.0 Use template rendering instead of AJAX loading
      * @return DBHTMLText|null
      */
     public function index(): ?DBHTMLText

--- a/src/Extension/ExpirationDataExtension.php
+++ b/src/Extension/ExpirationDataExtension.php
@@ -2,9 +2,9 @@
 
 namespace Dynamic\Notifications\Extension;
 
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension\Extension;
 
-class ExpirationDataExtension extends DataExtension
+class ExpirationDataExtension extends Extension
 {
     /**
      * @var array

--- a/src/Extension/ExpirationDataExtension.php
+++ b/src/Extension/ExpirationDataExtension.php
@@ -2,7 +2,7 @@
 
 namespace Dynamic\Notifications\Extension;
 
-use SilverStripe\Core\Extension\Extension;
+use SilverStripe\Core\Extension;
 
 class ExpirationDataExtension extends Extension
 {

--- a/src/Extension/PageControllerExtension.php
+++ b/src/Extension/PageControllerExtension.php
@@ -6,7 +6,7 @@ use Dynamic\Notifications\Model\PopUp;
 use Dynamic\Notifications\Model\Violator;
 use SilverStripe\Control\Cookie;
 use SilverStripe\Core\Extension;
-use SilverStripe\ORM\ArrayList;
+use SilverStripe\Model\List\ArrayList;
 use SilverStripe\ORM\DataList;
 use SilverStripe\View\Requirements;
 

--- a/src/Extension/PageControllerExtension.php
+++ b/src/Extension/PageControllerExtension.php
@@ -24,9 +24,9 @@ class PageControllerExtension extends Extension
     }
 
     /**
-     * @return PopUp
+     * @return PopUp|null
      */
-    public function getPopUp(): PopUp
+    public function getPopUp(): ?PopUp
     {
         $list = PopUp::get()->filter([
             'StartTime:LessThanOrEqual' => date("Y-m-d H:i:s", strtotime('now')),

--- a/src/Extension/PageControllerExtension.php
+++ b/src/Extension/PageControllerExtension.php
@@ -3,6 +3,7 @@
 namespace Dynamic\Notifications\Extension;
 
 use Dynamic\Notifications\Model\PopUp;
+use Dynamic\Notifications\Model\Violator;
 use SilverStripe\Control\Cookie;
 use SilverStripe\Core\Extension;
 use SilverStripe\ORM\ArrayList;
@@ -15,11 +16,30 @@ use SilverStripe\View\Requirements;
 class PageControllerExtension extends Extension
 {
     /**
+     * @var bool
+     * @config
+     * @deprecated 3.0.0 Use template rendering instead of AJAX loading
+     */
+    private static $use_ajax_violators = false;
+
+    /**
      * @return void
      */
     public function onAfterInit(): void
     {
-        Requirements::javascript('dynamic/silverstripe-site-notifications: client/js/notifications.js');
+        // AJAX loading is deprecated but still supported for backwards compatibility
+        if ($this->owner->config()->get('use_ajax_violators')) {
+            user_error(
+                'AJAX violator loading is deprecated and will be removed in version 3.0.0. ' .
+                'Set PageController.use_ajax_violators to false and use template rendering instead.',
+                E_USER_DEPRECATED
+            );
+            Requirements::javascript('dynamic/silverstripe-site-notifications: client/js/notifications.js');
+        } else {
+            // Use template rendering with cookie handling
+            Requirements::javascript('dynamic/silverstripe-site-notifications: client/js/violator.js');
+        }
+
         Requirements::javascript('dynamic/silverstripe-site-notifications: client/js/popup.js');
     }
 
@@ -44,5 +64,35 @@ class PageControllerExtension extends Extension
         });
 
         return $list->shuffle()->first();
+    }
+
+    /**
+     * Get active violators for template rendering
+     * 
+     * @return ArrayList<Violator>
+     */
+    public function getViolators(): ArrayList
+    {
+        $now = date("Y-m-d H:i:s");
+        $list = Violator::get();
+
+        $list = $list->filterByCallback(function ($item) use ($now) {
+            // Check date range - if dates are set, violator must be within range
+            if ($item->StartTime && $item->StartTime >= $now) {
+                return false;
+            }
+            if ($item->EndTime && $item->EndTime <= $now) {
+                return false;
+            }
+
+            // Check ShowOnce cookie
+            if ($item->ShowOnce && Cookie::get($item->CookieName)) {
+                return false;
+            }
+
+            return true;
+        });
+
+        return $list->sort('Sort');
     }
 }

--- a/src/Model/PopUp.php
+++ b/src/Model/PopUp.php
@@ -13,7 +13,7 @@ use SilverStripe\Forms\TextField;
 use SilverStripe\LinkField\Form\LinkField;
 use SilverStripe\LinkField\Models\Link;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\ValidationResult;
+use SilverStripe\Core\Validation\ValidationResult;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\Parsers\URLSegmentFilter;
 

--- a/src/Model/PopUp.php
+++ b/src/Model/PopUp.php
@@ -118,9 +118,16 @@ class PopUp extends DataObject
                         ]),
                     TextField::create('CookieName')
                         ->setTitle('Cookie Name')
-                        ->setDescription('Optional. Set a cookie name if the alert shows once, a cookie name will generate if none given.')
+                        ->setDescription(
+                            'Optional. Set a cookie name if the alert shows once, ' .
+                            'a cookie name will generate if none given.'
+                        )
                 )->setName('cookie_settings')
-                    ->setDescription('Should this alert show only once? If "yes" you can set a name, or a cookie name will be generated. The cookie name will be have spaces and special characters removed.'),
+                    ->setDescription(
+                        'Should this alert show only once? If "yes" you can set a name, ' .
+                        'or a cookie name will be generated. The cookie name will have ' .
+                        'spaces and special characters removed.'
+                    ),
                 'Title'
             );
 

--- a/src/Model/PopUp.php
+++ b/src/Model/PopUp.php
@@ -2,7 +2,7 @@
 
 namespace Dynamic\Notifications\Model;
 
-use Dynamic\Notifications\Extension\ContentDataExtension;
+
 use Dynamic\Notifications\Extension\ExpirationDataExtension;
 use SilverStripe\Assets\Image;
 use SilverStripe\Control\Cookie;

--- a/src/Model/Violator.php
+++ b/src/Model/Violator.php
@@ -9,7 +9,7 @@ use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\ValidationResult;
+use SilverStripe\Core\Validation\ValidationResult;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\Parsers\URLSegmentFilter;
 

--- a/src/Model/Violator.php
+++ b/src/Model/Violator.php
@@ -2,7 +2,7 @@
 
 namespace Dynamic\Notifications\Model;
 
-use Dynamic\Notifications\Extension\ContentDataExtension;
+
 use Dynamic\Notifications\Extension\ExpirationDataExtension;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldGroup;

--- a/src/Model/Violator.php
+++ b/src/Model/Violator.php
@@ -110,9 +110,16 @@ class Violator extends DataObject
                         ]),
                     TextField::create('CookieName')
                         ->setTitle('Cookie Name')
-                        ->setDescription('Optional. Set a cookie name if the alert shows once, a cookie name will generate if none given.')
+                        ->setDescription(
+                            'Optional. Set a cookie name if the alert shows once, ' .
+                            'a cookie name will generate if none given.'
+                        )
                 )->setName('cookie_settings')
-                    ->setDescription('Should this alert show only once? If "yes" you can set a name, or a cookie name will be generated. The cookie name will be have spaces and special characters removed.'),
+                    ->setDescription(
+                        'Should this alert show only once? If "yes" you can set a name, ' .
+                        'or a cookie name will be generated. The cookie name will have ' .
+                        'spaces and special characters removed.'
+                    ),
                 'Title'
             );
 

--- a/templates/Includes/Violator.ss
+++ b/templates/Includes/Violator.ss
@@ -1,2 +1,2 @@
-<div class="violators alert alert-warning alert-dismissible fade show mb-0" role="alert">
+<div class="violators" role="alert">
 </div>

--- a/templates/Includes/Violator.ss
+++ b/templates/Includes/Violator.ss
@@ -1,2 +1,15 @@
-<div class="violators" role="alert">
-</div>
+<% if $Violators %>
+    <% loop $Violators %>
+        <% set $violatorClass = "violators__violator container-fluid text-center alert alert-warning alert-dismissible mb-0 border-top-0 border-end-0 border-start-0 rounded-0" %>
+        <% if $Last %>
+            <% set $violatorClass = "$violatorClass border-bottom-0" %>
+        <% end_if %>
+        <div id="violator-{$ID}" class="$violatorClass" role="alert"<% if $ShowOnce %> data-cookiename="$CookieName"<% end_if %>>
+            <strong>$Title</strong>
+            <div class="violator-text">
+                $Content
+            </div>
+            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    <% end_loop %>
+<% end_if %>

--- a/templates/ViolatorObjects.ss
+++ b/templates/ViolatorObjects.ss
@@ -1,6 +1,6 @@
 <% if $Violators %>
 <% loop $Violators %>
-<div id="violator-{$ID}" class="violators__violator container-fluid text-center" role="alert"<% if $ShowOnce %> data-cookiename="$CookieName"<% end_if %>>
+<div id="violator-{$ID}" class="violators__violator container-fluid text-center alert alert-warning alert-dismissible fade show mb-0" role="alert"<% if $ShowOnce %> data-cookiename="$CookieName"<% end_if %>>
     <strong>$Title</strong><br>
     <div class="violator-textn">
         $Content


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Drop Silverstripe 5 support. Major version 3.0 requiring Silverstripe 6 only.

## Changes
- composer.json: recipe-cms ^6, linkfield ^5, vendor-plugin ^3, recipe-testing ^4
- require-dev: elemental ^6
- Extension namespace fix
- ArrayList namespace change for SS6
- phpunit.xml.dist: PHPUnit 11 format
- branch-alias: dev-3 → 3.x-dev
- README: updated requirements, switched from linkable to linkfield

## Version History
| Version | Branch | Silverstripe |
|---------|--------|-------------|
| 3.x     | 3      | ^6          |
| 2.x     | 2      | ^5          |
| 1.x     | 1.0/1.1| ^4          |
