### PR TITLE
docs: fix H1 typo, add badges, fix license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
-# Silverstripe Site Noitifcations
+# Silverstripe Site Notifications
 
 Display site notifications like violators and pop ups
 
+[![CI](https://github.com/dynamic/silverstripe-site-notifications/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamic/silverstripe-site-notifications/actions/workflows/ci.yml) [![Sponsors](https://img.shields.io/badge/GitHub-Sponsors-ff69b4?logo=github)](https://github.com/sponsors/dynamic)
+
+[![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-site-notifications/v/stable)](https://packagist.org/packages/dynamic/silverstripe-site-notifications)
+[![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-site-notifications/downloads)](https://packagist.org/packages/dynamic/silverstripe-site-notifications)
+[![Latest Unstable Version](https://poser.pugx.org/dynamic/silverstripe-site-notifications/v/unstable)](https://packagist.org/packages/dynamic/silverstripe-site-notifications)
+[![License](https://poser.pugx.org/dynamic/silverstripe-site-notifications/license)](https://packagist.org/packages/dynamic/silverstripe-site-notifications)
+
 ## Requirements
 
-* Silverstripe ^6
-* silverstripe/linkfield ^5
+* SilverStripe: ^6
+* silverstripe/linkfield: ^5
 
 ## Installation
 
@@ -14,7 +21,8 @@ composer require dynamic/silverstripe-site-notifications
 ```
 
 ## License
-See [License](license.md)
+
+See [License](LICENSE.md)
 
 ## Configuration
 
@@ -24,14 +32,13 @@ Apply `SiteTreeDataExtension` to `SiteTree`:
 SilverStripe\CMS\Model\SiteTree:
   extensions:
     - Dynamic\Notifications\Extension\SiteTreeDataExtension
-
 ```
 
 ## Template
 
 In your top-level `Page.ss` template:
 
-```yaml
+```html
 <% if $Violators %>
     <div class="violators">
         <% loop $Violators %>
@@ -58,9 +65,11 @@ In your top-level `Page.ss` template:
 ```
 
 ## Maintainers
-*  [Dynamic](http://www.dynamicagency.com) (<dev@dynamicagency.com>)
+
+ *  [Dynamic](https://www.dynamicagency.com) (<dev@dynamicagency.com>)
 
 ## Bugtracker
+
 Bugs are tracked in the issues section of this repository. Before submitting an issue please read over
 existing issues to ensure yours is unique.
 
@@ -75,4 +84,5 @@ If the issue does look like a new bug:
 Please report security issues to the module maintainers directly. Please don't file security issues in the bugtracker.
 
 ## Development and contribution
+
 If you would like to make contributions to the module please ensure you raise a pull request and discuss with the module maintainers.


### PR DESCRIPTION
## Summary

Standardizes documentation as part of the Essentials suite-wide documentation update.

## Changes

- **README**: Fix H1 typo ("Noitifcations" → "Notifications"), add CI + Packagist badge block, fix `license.md` → `LICENSE.md` link, fix template code-fence label (`yaml` → `html` for `.ss` template syntax), normalize Maintainers spacing

## Type of change

- [x] Documentation update

## Related Issues

Part of the Essentials suite documentation standardization.